### PR TITLE
Added depend on ruby for metaruby

### DIFF
--- a/metaruby/package.xml
+++ b/metaruby/package.xml
@@ -11,6 +11,9 @@
   <run_depend>catkin</run_depend>
   <buildtool_depend>cmake</buildtool_depend>
 
+  <build_depend>ruby</build_depend>
+
+  <run_depend>ruby</run_depend>
   <run_depend>utilrb</run_depend>
 
   <export>


### PR DESCRIPTION
Ruby needs to be installed at build time due to (https://github.com/orocos-gbp/metaruby-release/blob/master/metaruby/CMakeLists.txt#L4), and it is good practice to specifically list it as a runtime dependency instead of relying on `utilrb` to ensure the installation of Ruby.

Example build break: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-metaruby_binaryrpm_heisenbug_x86_64/2/consoleFull
